### PR TITLE
Changed name: LRT Kultūra to LRT Plius

### DIFF
--- a/skynet-pl-local.m3u
+++ b/skynet-pl-local.m3u
@@ -77,14 +77,15 @@ udp://@233.136.41.178:1234
 
 # SPORTS ########################################
 
+#HD
 #EXTINF:-1,TVPlay Sports
 udp://@239.255.12.10:1234
 
+#EXTINF:-1,TVPlay Sports
+udp://@233.136.41.36:1234
+
 #EXTINF:-1,TVPlay Sports +
 udp://239.255.12.74:1234
-
-#EXTINF:-1,Viasat Sport Baltic
-udp://@233.136.41.36:1234
 
 #EXTINF:-1,Viasat Motor
 udp://@233.136.41.125:1234

--- a/skynet-pl-local.m3u
+++ b/skynet-pl-local.m3u
@@ -11,7 +11,7 @@ udp://@233.136.41.170:1234
 #EXTINF:-1,LRT Lituanica
 udp://@233.136.41.147:1234
 
-#EXTINF:-1,LRT Kultūra
+#EXTINF:-1,LRT Plius
 udp://@233.136.41.171:1234
 
 # HD

--- a/tools/WebGrab++.config.xml
+++ b/tools/WebGrab++.config.xml
@@ -22,7 +22,7 @@
 <channel site="tv24.lt" xmltv_id="MTV Hits" site_id="mtv-hits" update="i">MTV Hits</channel>
 <channel site="tv24.lt" xmltv_id="MTV Music" site_id="mtv-music" update="i">MTV Music</channel>
 <channel site="tv24.lt" xmltv_id="LRT Televizija" site_id="lrt-televizija" update="i">LRT Televizija</channel>
-<channel site="tv24.lt" xmltv_id="LRT Kultūra" site_id="lrt-kultura" update="i">LRT Kultūra</channel>
+<channel site="tv24.lt" xmltv_id="LRT Plius" site_id="lrt-plius" update="i">LRT Plius</channel>
 <channel site="tv24.lt" xmltv_id="TV3" site_id="tv3-4" update="i">TV3</channel>
 <channel site="tv24.lt" xmltv_id="LNK" site_id="lnk" update="i">LNK</channel>
 <channel site="tv24.lt" xmltv_id="TV1" site_id="tv1" update="i">TV1</channel>


### PR DESCRIPTION
EPG is not generated for the LRT Plius channel because of the wrong naming.